### PR TITLE
Bugfix setting repository permissions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,6 +3,7 @@
 #   --------------------------------------------------------
 #   import os
 #
+#   # Example variable
 #   EXAMPLE_VARIABLE = os.getenv("EXAMPLE_VARIABLE")
 #   --------------------------------------------------------
 #
@@ -16,7 +17,7 @@
 # committed
 sed -n 's/^export \(.*\)$/\1/p' .envrc .secrets | sed -e 's?$(pwd)?'"$(pwd)"'?g' > .env
 
-# Add the working directory to PYTHONPATH; allows Jupyter notebooks in the `notebooks` folder to import `src`
+# Add the working directory to `PYTHONPATH`; allows Jupyter notebooks in the `notebooks` folder to import `src`
 export PYTHONPATH="$PYTHONPATH:$(pwd)"
 
 # Import secrets from an untracked file `.secrets`

--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
 # D203: 1 blank line required before class docstring
 # W503: line break before binary operator
-exclude = venv*,__pycache__,node_modules,bower_components,migrations,__init__.py
+exclude = venv*,__pycache__,node_modules,bower_components,migrations
 ignore = D203,W503
 max-complexity = 9
 max-line-length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/vim,venv,pydev,flask,dotenv,django,direnv,python,virtualenv,pycharm+all,visualstudio,jupyternotebooks,macos,linux,windows
-# Edit at https://www.toptal.com/developers/gitignore?templates=vim,venv,pydev,flask,dotenv,django,direnv,python,virtualenv,pycharm+all,visualstudio,jupyternotebooks,macos,linux,windows
+# Created by https://www.toptal.com/developers/gitignore/api/vim,venv,pydev,linux,macos,flask,dotenv,django,direnv,python,windows,virtualenv,pycharm+all,visualstudio,jupyternotebooks,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim,venv,pydev,linux,macos,flask,dotenv,django,direnv,python,windows,virtualenv,pycharm+all,visualstudio,jupyternotebooks,visualstudiocode
 
 ### direnv ###
 .direnv
@@ -464,6 +464,17 @@ tags
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
 
+### VisualStudioCode ###
+.vscode/*
+#!.vscode/tasks.json
+#!.vscode/launch.json
+*.code-workspace
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
 ### Windows ###
 # Windows thumbnail cache files
 Thumbs.db
@@ -841,7 +852,7 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-# End of https://www.toptal.com/developers/gitignore/api/vim,venv,pydev,flask,dotenv,django,direnv,python,virtualenv,pycharm+all,visualstudio,jupyternotebooks,macos,linux,windows
+# End of https://www.toptal.com/developers/gitignore/api/vim,venv,pydev,linux,macos,flask,dotenv,django,direnv,python,windows,virtualenv,pycharm+all,visualstudio,jupyternotebooks,visualstudiocode
 
 ### GitHub Organisation Administration ###
 
@@ -855,12 +866,10 @@ data/*
 data/external/*
 data/raw/*
 data/interim/*
-data/logs/*
 data/processed/*
 !data/external/.gitkeep
 !data/raw/.gitkeep
 !data/interim/.gitkeep
-!data/logs/.gitkeep
 !data/processed/.gitkeep
 
 # Ignore the `docs/reference/api` folder
@@ -868,3 +877,7 @@ docs/reference/api/*
 
 # Ignore the `.secrets` file
 .secrets
+
+# Ignore r artifacts
+*.Renviron
+*.Rhistory

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,28 +2,28 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: master
+    rev: 3.8.4
     hooks:
     -   id: flake8
         args: ["src"]
 -   repo: https://github.com/Yelp/detect-secrets
-    rev: v0.13.1
+    rev: v1.0.3
     hooks:
     -   id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: .*/tests/.*
--   repo: https://github.com/aflc/pre-commit-jupyter
-    rev: v1.1.0
-    hooks:
-    -   id: jupyter-notebook-cleanup
-        args:
-        -   --remove-kernel-metadata
-        -   --pin-patterns
-        -   "[keep_output]"
+- repo: https://github.com/kynan/nbstripout
+  rev: 0.3.9
+  hooks:
+    - id: nbstripout
+      args:
+        - --extra-keys
+        - "metadata.colab metadata.kernelspec cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v3.4.0
     hooks:
     -   id: check-added-large-files
         args: ["--maxkb=5120"]
     -   id: end-of-file-fixer
+        exclude: '\.Rd'
     -   id: trailing-whitespace

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,18 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-04-14T12:06:53Z",
+  "version": "1.0.3",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +21,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,11 +34,14 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -51,26 +53,57 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
     "docs/user_guide/creating_github_api_token.md": [
       {
-        "hashed_secret": "96d6b1f680dfaefe5559ed7a0d3a8f54af426877",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "docs/user_guide/creating_github_api_token.md",
+        "hashed_secret": "04fff6bed423db250a00ff55ed92d32dad86ee9e",
         "is_verified": false,
         "line_number": 20,
-        "type": "Secret Keyword"
+        "is_secret": false
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-05-21T11:56:55Z"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
-.PHONY: coverage coverage_html docs docs_check_external_links help prepare_docs_folder requirements
+.PHONY:
+	coverage
+	coverage_html
+	coverage_xml
+	docs
+	docs_check_external_links
+	help
+	prepare_docs_folder
+	requirements
 
 .DEFAULT_GOAL := help
 
@@ -7,14 +15,6 @@ requirements:
 	python3 -m pip install -U pip setuptools
 	python3 -m pip install -r requirements.txt
 	pre-commit install
-
-## Run code coverage
-coverage: requirements
-	coverage run -m pytest
-
-## Run code coverage and produce a HTML report
-coverage_html: coverage
-	coverage html
 
 ## Create a `docs/_build` folder, if it doesn't exist. Otherwise delete any sub-folders and their contents within it
 prepare_docs_folder:
@@ -28,6 +28,18 @@ docs: prepare_docs_folder requirements
 ## Check external links in the Sphinx documentation using linkcheck in the docs/_build folder from a clean build
 docs_check_external_links: prepare_docs_folder requirements
 	sphinx-build -b linkcheck ./docs ./docs/_build
+
+## Run code coverage
+coverage: requirements
+	coverage run -m pytest
+
+## Run code coverage, and produce a HTML output
+coverage_html: coverage
+	coverage html
+
+## Run code coverage, and produce an XML output
+coverage_xml: coverage
+	coverage xml
 
 ## Get help on all make commands; referenced from https://github.com/drivendata/cookiecutter-data-science
 help:

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ To run this project, you need a `.secrets` file with secrets/credentials as envi
 [documentation][docs-loading-environment-variables-secrets] for further guidance. The secrets/credentials should have
 the following environment variable name(s):
 
-| Secret/credential              | Environment variable name | Description                                                 |
-|--------------------------------|---------------------------|-------------------------------------------------------------|
-| GitHub personal access token   | `GITHUB_API_KEY`          | See [here][docs-github-token] for further information       |
-| GitHub organisation name       | `GITHUB_ORGANISATION`     | The GitHub organisation name, e.g. `alphagov`               |
-| GitHub organisation admin team | `GITHUB_ADMIN_TEAM_SLUG`  | The GitHub team name that should have repo admin privileges |
+| Secret/credential            | Environment variable name | Description                                           |
+|------------------------------|---------------------------|-------------------------------------------------------|
+| GitHub personal access token | `GITHUB_API_KEY`          | See [here][docs-github-token] for further information |
+| GitHub organisation name     | `GITHUB_ORGANISATION`     | The GitHub organisation name, e.g. `alphagov`         |
+| GitHub organisation team     | `GITHUB_TEAM_SLUG`        | The GitHub team name that should have repo privileges |
 
 Once you've added these environment variables to `.secrets` you will need to
 [load them via `.envrc`][docs-loading-environment-variables].

--- a/docs/contributor_guide/pre_commit_hooks.md
+++ b/docs/contributor_guide/pre_commit_hooks.md
@@ -9,25 +9,36 @@ ensuring that all of our code adheres to a certain quality standard.
 
 For this repository, we are using `pre-commit` for a number of purposes:
 
-- Checking for any secrets being committed accidentally;
-- Checking for any large files (over 5MB) being committed; and
-- Cleaning Jupyter notebooks, which means removing all outputs and execution counts.
+- Checking for secrets being committed accidentally — see [here](#definition-of-a-secret-according-to-detect-secrets)
+  for the definition of a "secret";
+- Checking for any large files (over 5 MB) being committed; and
+- Cleaning Jupyter notebooks, which means removing all outputs, execution counts, Python kernels, and, for Google
+  Colaboratory (Colab), stripping out user information.
 
 We have configured `pre-commit` to run automatically on _every commit_. By running on each commit, we ensure that
-`pre-commit` will be able to detect all contraventions and keep our repo in a healthy state.
+`pre-commit` will be able to detect all contraventions and keep our repository in a healthy state.
+
+> ⚠️ **No pre-commit hooks will be run on Google Colab notebooks pushed directly to GitHub**. For security reasons, it
+> is highly recommended that you manually download your notebook, and commit up locally to ensure pre-commit hooks are
+> executed on your changes
 
 ## Installation
 
 In order for `pre-commit` to run, action is needed to configure it on your system.
 
 - Install the `pre-commit` package into your Python environment from `requirements.txt`; and
-- Run `pre-commit install` in your terminal to set-up `pre-commit` to run when code is _committed_.
+- Run `pre-commit install` in your terminal to set up `pre-commit` to run when code is _committed_.
 
 ## Using the `detect-secrets` pre-commit hook
 
-We use [`detect-secrets`][detect-secrets] to check that no secrets are accidentally committed. This hook requires you
-to generate a baseline file if one is not already present within the root directory. To create the baseline file, run
-the following at the root of the repository:
+> ⚠️ The `detect-secrets` package does its best to prevent accidental committing of secrets, but it can't catch
+> everything. **It doesn't replace good software development practices!** See the definition of a secret
+> [here](#definition-of-a-secret-according-to-detect-secrets) for further information.
+
+We use [`detect-secrets`][detect-secrets] to check that no secrets, as defined
+[here](#definition-of-a-secret-according-to-detect-secrets), are accidentally committed. This hook requires you to
+generate a baseline file if one is not already present within the root directory. To create the baseline file, run the
+following at the root of the repository:
 
 ```shell
 detect-secrets scan > .secrets.baseline
@@ -40,40 +51,106 @@ detect-secrets audit .secrets.baseline
 ```
 
 When you run this command, you'll enter an interactive console and be presented with a list of high-entropy string
-and/or anything which _could_ be a secret, and asked to verify whether or not this is the case. By doing this, the hook
-will be in a position to know if you're later committing any _new_ secrets to the repo and it will be able to alert you
-accordingly.
+and/or anything which _could_ be a secret, and asked to verify whether this is the case. By doing this, the hook will
+be in a position to know if you're later committing any _new_ secrets to the repository, and it will be able to alert
+you accordingly.
+
+### Definition of a "secret" according to `detect-secrets`
+
+The [`detect-secrets` documentation][detect-secrets], as of January 2021, says it works:
+
+> ...by running periodic diff outputs against heuristically crafted \[regular expression\] statements, to identify
+> whether any new secret has been committed.
+
+This means it uses regular expression patterns to scan your code changes for anything that **looks like a secret
+according to one or more of these regular expression patterns**. By definition, there are only a limited number of
+patterns, so the `detect-secrets` package cannot detect every conceivable type of secret.
+
+To understand what types of secrets will be detected, read the [caveats][detect-secrets-caveats], and the list of
+[supported plugins][detect-secrets-plugins] that the package uses. Also, you should use secret variable names that
+contain words that will trip the KeywordDetector plugin; see the `DENYLIST` variable
+[here][detect-secrets-keyword-detector] for the full list of words.
 
 ### If `pre-commit` detects secrets during commit
 
 If `pre-commit` detects any secrets when you try to create a commit, it will detail what it found and where to go to
 check the secret.
 
-If the detected secret is a false-positive, you should update the `.secrets.baseline` through the following steps:
+If the detected secret is a false positive, there are two options to resolve this, and prevent your commit from being
+blocked: [inline allowlisting (recommended)](#inline-allowlisting-recommended) or
+[updating `.secrets.baseline`](#updating-secretsbaseline).
 
-- Run `detect-secrets scan --update .secrets.baseline` from the root folder in the terminal to index the
-  false-positive(s);
+In either case, if an actual secret is detected (or a combination of actual secrets and false positives), first remove
+the actual secret before following either of these processes.
+
+#### Inline allowlisting (recommended)
+
+To exclude a false positive, add a `pragma` comment such as:
+
+```python
+secret = "Password123"  # pragma: allowlist secret
+```
+
+or
+
+```python
+#  pragma: allowlist nextline secret
+secret = "Password123"
+```
+
+If the detected secret is actually a secret (or other sensitive information), remove the secret and re-commit; there is
+no need to add any `pragma` comments.
+
+If your commit contains a mixture of false positives and actual secrets, remove the actual secrets first before adding
+`pragma` comments to the false positives.
+
+#### Updating `.secrets.baseline`
+
+To exclude a false positive, you can also update the `.secrets.baseline` through the following steps:
+
+- Run `detect-secrets scan --baseline .secrets.baseline` from the root folder in the terminal to index the
+  false positive(s);
 - Next, audit all indexed secrets via `detect-secrets audit .secrets.baseline` (the same as during initial set-up, if a
   `.secrets.baseline` doesn't exist); and
-- Finally, ensure that you commit the updated `.secrets.baseline` in the same commit as the false-positive(s) it has
+- Finally, ensure that you commit the updated `.secrets.baseline` in the same commit as the false positive(s) it has
   been updated for.
 
 If the detected secret is actually a secret (or other sensitive information), remove the secret and re-commit. There is
-no need to update the secrets baseline in this case.
+no need to update the `.secrets.baseline` file in this case.
 
-If your commit contains a mixture of false-positives and actual secrets, remove the actual secrets first before
-updating and auditing the secrets baseline.
+If your commit contains a mixture of false positives and actual secrets, remove the actual secrets first before
+updating and auditing the `.secrets.baseline` file.
 
 ## Keeping specific Jupyter notebook outputs
 
 It may be necessary or useful to keep certain output cells of a Jupyter notebook, for example charts or graphs
-visualising some set of data. To do this, add the following comment at the top of the input block:
+visualising some set of data. To do this, according to the documentation for the [`nbstripout`][nbstripout] package,
+either:
 
-```julia
-# [keep_output]
+1. Add a `keep_output` tag to the desired cell; or
+2. Add `"keep_output": true` to the desired cell's metadata.
+
+You can access cell tags or metadata in Jupyter by enabling the "Tags" or "Edit Metadata" toolbar
+(View > Cell Toolbar > Tags; View > Cell Toolbar > Edit Metadata). For the tags approach, enter `keep_output` in the
+text field for each desired cell, and press the "Add tag" button. For the metadata approach, press the "Edit Metadata"
+button on each desired cell, and edit the metadata to look like this:
+
+```json
+{
+  "keep_output": true
+}
 ```
 
-This will tell the hook not to strip the resulting output of this cell, allowing it to be committed.
+This will tell the hook not to strip the resulting output of the desired cell(s), allowing the output(s) to be
+committed.
+
+>  ℹ️ Currently (March 2020) there is no way to add tags and/or metadata to Google Colab notebooks. It's strongly
+> suggested that you download the Colab as a .ipynb file, and edit tags and/or metadata using Jupyter _before_
+> committing the code if you want to keep some outputs.
 
 [detect-secrets]: https://github.com/Yelp/detect-secrets
+[detect-secrets-caveats]: https://github.com/Yelp/detect-secrets#caveats
+[detect-secrets-keyword-detector]: https://github.com/Yelp/detect-secrets/blob/master/detect_secrets/plugins/keyword.py
+[detect-secrets-plugins]: https://github.com/Yelp/detect-secrets#currently-supported-plugins
+[nbstripout]: https://github.com/kynan/nbstripout
 [pre-commit]: https://pre-commit.com/

--- a/notebooks/example_get_contributors_for_all_organisation_repositories.ipynb
+++ b/notebooks/example_get_contributors_for_all_organisation_repositories.ipynb
@@ -66,9 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get all the contributors for these repositories\n",
@@ -112,11 +110,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "",
-   "language": "python",
-   "name": ""
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/example_get_organisation_repositories.ipynb
+++ b/notebooks/example_get_organisation_repositories.ipynb
@@ -122,11 +122,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "",
-   "language": "python",
-   "name": ""
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/example_get_teams_for_all_organisation_repositories.ipynb
+++ b/notebooks/example_get_teams_for_all_organisation_repositories.ipynb
@@ -66,9 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get all the teams for these repositories\n",
@@ -112,11 +110,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "",
-   "language": "python",
-   "name": ""
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/example_set_team_permission_for_all_organisation_repositories.ipynb
+++ b/notebooks/example_set_team_permission_for_all_organisation_repositories.ipynb
@@ -58,10 +58,10 @@
    "source": [
     "## Getting the GitHub organisation team\n",
     "\n",
-    "You also need to define a `github.Team.Team` object for the GitHub organisation team you wish to use. You can use the following code to do this using the `GITHUB_ADMIN_TEAM_SLUG` environment variable. Alternatively, replace:\n",
+    "You also need to define a `github.Team.Team` object for the GitHub organisation team you wish to use. You can use the following code to do this using the `GITHUB_TEAM_SLUG` environment variable. Alternatively, replace:\n",
     "\n",
     "```python\n",
-    "os.getenv(\"GITHUB_ADMIN_TEAM_SLUG\")\n",
+    "os.getenv(\"GITHUB_TEAM_SLUG\")\n",
     "```\n",
     "\n",
     "with a string of your team name."
@@ -74,7 +74,7 @@
    "outputs": [],
    "source": [
     "# Get a `github.Team.Team` object for the GitHub organisation team you wish to use\n",
-    "g_team = g.get_organization(GITHUB_ORGANISATION).get_team_by_slug(os.getenv(\"GITHUB_ADMIN_TEAM_SLUG\"))"
+    "g_team = g.get_organization(GITHUB_ORGANISATION).get_team_by_slug(os.getenv(\"GITHUB_TEAM_SLUG\"))"
    ]
   },
   {
@@ -108,9 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# # Amend `g_team` permissions to admin in each of `organisation_repositories`\n",
@@ -179,11 +177,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "",
-   "language": "python",
-   "name": ""
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/notebooks/example_set_team_permission_for_all_organisation_repositories.ipynb
+++ b/notebooks/example_set_team_permission_for_all_organisation_repositories.ipynb
@@ -21,7 +21,12 @@
    "outputs": [],
    "source": [
     "from github import Github\n",
-    "from src import extract_attribute_from_dict_of_paginated_lists, find_organisation_repos, get_items_for_all_repos\n",
+    "from src import (\n",
+    "    add_team_with_permissions_to_all_repositories,\n",
+    "    extract_attribute_from_dict_of_paginated_lists,\n",
+    "    find_organisation_repos,\n",
+    "    get_items_for_all_repos\n",
+    ")\n",
     "import os"
    ]
   },
@@ -100,7 +105,7 @@
     "\n",
     "The permission level is defined as in the [GitHub REST APIv3 documentation][github-team-permissions]. The function returns nothing, but you should see the effect of it's actions on GitHub itself.\n",
     "\n",
-    "In our example, we will add `g_team` to all GitHub organisation repositories if not already added, and then set the team to have administrative privileges across all repositories.\n",
+    "In our example, we will add `g_team` to all GitHub organisation repositories if not already added, and then set the team to have write privileges across all repositories.\n",
     "\n",
     "[github-team-permissions]: https://docs.github.com/en/free-pro-team@latest/rest/reference/teams#add-or-update-team-project-permissions"
    ]
@@ -111,8 +116,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Amend `g_team` permissions to admin in each of `organisation_repositories`\n",
-    "# add_team_with_permissions_to_all_repositories(g_team, \"admin\", organisation_repositories)"
+    "# # Amend `g_team` permissions to write in each of `organisation_repositories`\n",
+    "# add_team_with_permissions_to_all_repositories(g_team, \"push\", list(organisation_repositories))"
    ]
   },
   {
@@ -125,7 +130,7 @@
     "\n",
     "This means you can take a subset of `organisation_repositories`, or even filter `organisation_repositories` so you only set a team's permissions for a specific list of repositories.\n",
     "\n",
-    "Let's add `g_team` to the first GitHub organisation repository in `organisation_repositories` if it is not already added, and then set the team to have administrative privileges."
+    "Let's add `g_team` to the first GitHub organisation repository in `organisation_repositories` if it is not already added, and then set the team to have write privileges."
    ]
   },
   {
@@ -134,8 +139,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# # Amend `g_team` permissions to admin in the first repository of `organisation_repositories`\n",
-    "# add_team_with_permissions_to_all_repositories(g_team, \"admin\", [organisation_repositories[0]])"
+    "# # Amend `g_team` permissions to write in the first repository of `organisation_repositories`\n",
+    "# add_team_with_permissions_to_all_repositories(g_team, \"push\", [organisation_repositories[0]])"
    ]
   },
   {
@@ -148,7 +153,7 @@
     "\n",
     "```python\n",
     "add_team_with_permissions_to_all_repositories(\n",
-    "    g_team, \"admin\", [r for r in organisation_repositories if r.name == \"<<<REPOSITORY_NAME>>>\"]\n",
+    "    g_team, \"push\", [r for r in organisation_repositories if r.name == \"<<<REPOSITORY_NAME>>>\"]\n",
     ")\n",
     "```\n",
     "\n",
@@ -160,7 +165,7 @@
     "\n",
     "```python\n",
     "add_team_with_permissions_to_all_repositories(\n",
-    "    g_team, \"admin\",\n",
+    "    g_team, \"push\",\n",
     "    [r for r in organisation_repositories if r.name in <<<REPOSITORY_NAME_LIST>>]\n",
     ")\n",
     "```\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ coverage==5.3
 decorator==4.4.2
 defusedxml==0.6.0
 Deprecated==1.2.10
-detect-secrets==0.14.3
+detect-secrets==1.0.3
 distlib==0.3.1
 docutils==0.16
 entrypoints==0.3

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,3 +12,8 @@ from src.make_data.get_items_for_repo import get_items_for_repo
 from src.make_data.get_items_for_all_repos import get_items_for_all_repos
 from src.utils.logger import Log, create_logger, logger
 from src.utils.parallelise_dictionary_processing import parallelise_dictionary_processing, parallelise_processing
+__all__ = ("add_team_with_permissions_to_all_repositories", "add_team_with_permissions_to_repository",
+           "check_team_added_already", "extract_attribute_from_dict_of_paginated_lists",
+           "extract_attribute_from_paginated_list_elements", "find_organisation_repos", "get_items_for_repo",
+           "get_items_for_all_repos", "Log", "create_logger", "logger", "parallelise_dictionary_processing",
+           "parallelise_processing",)


### PR DESCRIPTION
# Summary

Main change is to bugfix `notebooks/example_set_team_permission_for_all_organisation_repositories.ipynb`, where the `organisation_repositories` variable needs to be coerced into a list to work correctly (for all repositories). Also fixed the missing import for the `add_team_with_permissions_to_all_repositories` function in the same notebook.

Also amended the  permissions to write (`push`) rather than admin, and modified the environment variable `GITHUB_ADMIN_TEAM_SLUG` to `GITHUB_TEAM_SLUG`. Other changes are all to update the configuration files to the latest state on [`govcookiecutter`](https://github.com/ukgovdatascience/govcookiecutter).

# Checklists

<!--
These are DO-CONFIRM checklists; it CONFIRMs that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are irrelevant, please try and add a
comment stating why.

Incomplete pull/merge requests MAY be blocked until actions are resolved, or closed at the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] Code runs
- [x] Developments are **secure** and [**ethical**][data-ethics-framework]
- [x] Developments follow the AQA plan (see `docs/aqa/aqa_plan.md`)
- [x] You have made proportionate checks that the code works correctly
- [x] Test suite passes
- [x] Assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if necessary
- [x] [Minimum usable documentation][agilemodeling] written in the `docs` folder, and in other Markdown files where
      relevant

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
